### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can find the DODO Widget documentation [on the website](https://docs.dodoex
 
 ## Examples
 
-Inside the `examples` folder, there two different examples,
+Inside the `examples` folder, there are two different examples,
 
 For react app:
 


### PR DESCRIPTION
There is a typo in your text in the "Examples" section. Specifically:

"Inside the examples folder, there two different examples,"

The correct version:

"Inside the examples folder, there **are** two different examples,"

The word "are" is used instead of "is" to agree with the plural noun ("two different examples").

Corrected.